### PR TITLE
feat: Go モジュール初期化とプロジェクト構成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build output
+pfind

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.26.0-alpine3.23
+
+RUN apk add --no-cache git ca-certificates
+
+WORKDIR /workspace
+
+COPY go.mod ./
+RUN go mod download
+
+COPY . .
+
+CMD ["go", "build", "-trimpath", "./..."]

--- a/README.md
+++ b/README.md
@@ -234,3 +234,60 @@ pfind "panic" --json . | jq -r '.path'
 - `--follow-symlinks` は循環検出（訪問済みinode/realpath）を必須要件にする
 - ビルド: `go build -trimpath`
 - Goバージョン: 1.21以上必須（`slices`, `maps` パッケージ等）
+
+---
+
+## 13. ディレクトリ構成
+
+### 構成ツリー
+
+```
+pfind/
+├── main.go                        # エントリーポイント（cmd.Execute() のみ）
+├── go.mod
+├── go.sum
+├── README.md
+│
+├── cmd/
+│   ├── root.go                    # CLI フラグ定義・バリデーション・実行
+│   └── version.go                 # -V / --version 処理
+│
+├── internal/
+│   ├── config/
+│   │   └── config.go              # CLI オプション構造体（全パッケージ共通）
+│   ├── walker/
+│   │   ├── walker.go              # ディレクトリ再帰走査 → ファイルパス channel
+│   │   └── walker_test.go
+│   ├── filter/
+│   │   ├── filter.go              # include/exclude glob・バイナリ判定・max-bytes
+│   │   └── filter_test.go
+│   ├── matcher/
+│   │   ├── matcher.go             # fixed/regex/ignore-case パターンマッチ
+│   │   └── matcher_test.go
+│   ├── worker/
+│   │   ├── worker.go              # ワーカープール（ファイル読み込み→検索→結果送信）
+│   │   └── worker_test.go
+│   ├── output/
+│   │   ├── output.go              # Printer インターフェース + テキスト出力
+│   │   ├── json.go                # JSON Lines 出力
+│   │   └── output_test.go
+│   └── search/
+│       ├── search.go              # オーケストレーター（goroutine パイプライン制御）
+│       └── search_test.go
+│
+└── testdata/
+    └── fixtures/
+        ├── simple/                # 基本ファイルツリー（結合テスト用）
+        ├── unicode/               # Unicode ファイル名テスト用
+        └── binary/               # バイナリファイル判定テスト用
+```
+
+### 設計根拠
+
+| 判断 | 理由 |
+|------|------|
+| ルート `main.go`（`cmd/pfind/` ではない） | 単一バイナリのため。`go install` パスも自然になる |
+| `internal/` にすべてのロジック | 外部からのインポートをコンパイラレベルで禁止 |
+| `internal/config/` を独立させる | CLIフレームワーク依存を `cmd/` に閉じ、循環参照を防ぐ |
+| パイプラインステージ別パッケージ | walker / worker / output を個別にユニットテスト可能にする |
+| `testdata/fixtures/` | Go 慣例のテストデータ置き場（ビルド対象外） |

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,1 @@
+package cmd

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,1 @@
+package cmd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+    environment:
+      - GOFLAGS=-mod=mod
+    command: ["go", "build", "-trimpath", "./..."]

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module TsunoKento/pfind
+
+go 1.25.0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,1 @@
+package config

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -1,0 +1,1 @@
+package filter

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -1,0 +1,1 @@
+package filter

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -1,0 +1,1 @@
+package matcher

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -1,0 +1,1 @@
+package matcher

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -1,0 +1,1 @@
+package output

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,0 +1,1 @@
+package output

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,1 @@
+package output

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -1,0 +1,1 @@
+package search

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -1,0 +1,1 @@
+package search

--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -1,0 +1,1 @@
+package walker

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -1,0 +1,1 @@
+package walker

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,0 +1,1 @@
+package worker

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -1,0 +1,1 @@
+package worker

--- a/main.go
+++ b/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}


### PR DESCRIPTION
## Summary

- `go mod init` で Go モジュールを初期化
- `main.go` / `cmd/` / `internal/` のディレクトリ構成を作成
- `.gitignore` にビルド成果物を除外設定を追加
- Docker 環境 (`Dockerfile` / `docker-compose.yml`) を構築
- README にディレクトリ構造のセクションを追加

## Test plan

- [x] `go build -trimpath ./...` がエラーなしで通ること
- [x] `docker compose run --rm app go test ./...` が実行できること

Closes #1